### PR TITLE
修复navigator的兼容性问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"build:main": "npm run copyFiles:main && tsc -p tsconfig.json",
 		"build:module": "npm run copyFiles:module && tsc -p tsconfig.module.json",
 		"build:umd": "npm run copyFiles:umd && tsc -p tsconfig.brower.json",
-    	"copyFiles:main": "copyfiles -u 1 \"src/**/*.js\" build/main",
-    	"copyFiles:module": "copyfiles -u 1 \"src/**/*.js\" build/module",
-    	"copyFiles:umd": "copyfiles -u 1 \"src/**/*.js\" build/umd",
+		"copyFiles:main": "copyfiles -u 1 \"src/**/*.js\" build/main",
+		"copyFiles:module": "copyfiles -u 1 \"src/**/*.js\" build/module",
+		"copyFiles:umd": "copyfiles -u 1 \"src/**/*.js\" build/umd",
 		"build:browser": "webpack",
 		"fix": "run-s fix:*",
 		"fix:prettier": "prettier \"src/**/*.ts\" --write",
@@ -57,6 +57,7 @@
 	},
 	"dependencies": {
 		"axios": "^0.19.2",
+		"conf-global": "^1.0.0",
 		"crypto-js": "^4.0.0",
 		"jsencrypt": "^3.1.0",
 		"jwt-decode": "^2.2.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "conf-global"
 export * from './lib/management/ManagementClient';
 export * from './lib/management/types';
 export * from './lib/management/ManagementTokenProvider';

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -224,8 +224,8 @@ export const convertUdvToKeyValuePair = (
 };
 
 export const isWechatBrowser = () =>
-  typeof navigator !== 'undefined' &&
-  /MicroMessenger/i.test(navigator?.userAgent);
+  typeof globalThis.navigator !== 'undefined' &&
+  /MicroMessenger/i.test(globalThis.navigator?.userAgent);
 
 export const formatAuthorizedResources = (resources: any[]) => {
   return resources.map(resource => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,11 @@ concordance@^4.0.0:
     semver "^5.5.1"
     well-known-symbols "^2.0.0"
 
+conf-global@^1.0.0:
+  version "1.0.0"
+  resolved "https://nexus.forchange.cn/repository/npm-group/conf-global/-/conf-global-1.0.0.tgz#670ec9554ab132df084b362a565656202480f2ae"
+  integrity sha512-UWGiE8jq6iQTCMqKW0AIOXTjVZytouGSjlcOEWR8z6TdZ0gHJyuF9otg9y/rN0Cl0DDPfeFsPUR0z7s9+SQeXw==
+
 configstore@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npm.taobao.org/configstore/download/configstore-4.0.0.tgz#5933311e95d3687efb592c528b922d9262d227e7"


### PR DESCRIPTION
# 更改了以下内容
+ 增加兼容性的全局变量 `globalThis`
+ 将 `navigator`  改为 没有兼容问题的引用方式 `globalThis.navigator`

_问题详情请看[issues-77](https://github.com/Authing/authing.js/issues/77)_

# 备注
+ `src/lib/jencrypt.js` 中也存在有问题的 `navigator`，但该文件看起来像是编译后的文件，目前不清楚该文件的作用，所以没有将该文件的  navigator 改成 `globalThis.navigator`
+ 本次只修复了全局变更`navigator`的使用方式，其它全局变量没有修复，建议将所有的全局变量都更换为通过  `globalThis` 属性的方式引用，比如  `globalThis.navigator`