### PR TITLE
fix(IUserInfo): Add phone property

### DIFF
--- a/packages/web/src/global.ts
+++ b/packages/web/src/global.ts
@@ -198,6 +198,7 @@ export interface IUserInfo {
   lastLogin?: string
   loginsCount?: number
   passwordLastSetAt?: string
+  phone?: string
   phoneCountryCode?: string
   phoneVerified?: boolean
   resetPasswordOnNextLogin?: boolean


### PR DESCRIPTION
fix: Add phone property to IUserInfo

This commit adds the missing phone property to the IUserInfo interface, addressing a crucial gap in the existing definition.

To accomplish this, the following changes were made:
- Updated the IUserInfo interface in the appropriate file to include the phone property.

Please review and merge this commit at your earliest convenience.

Co-authored-by: GeniusCorn [hi@nicecorn.com](mailto:hi@nicecorn.com)